### PR TITLE
QImage::constBits is qt >= 4.7 only

### DIFF
--- a/src/PDF.cpp
+++ b/src/PDF.cpp
@@ -251,7 +251,7 @@ void PDF::generateTexture(QRectF screenRect, QRectF fullRect, float tX, float tY
         // put the RGB image to the already-created texture
         // glTexSubImage2D uses the existing texture and is more efficient than other means
         glBindTexture(GL_TEXTURE_2D, textureId_);
-        glTexSubImage2D(GL_TEXTURE_2D, 0, 0,0, image.width(), image.height(), GL_BGRA, GL_UNSIGNED_BYTE, image.constBits());
+        glTexSubImage2D(GL_TEXTURE_2D, 0, 0,0, image.width(), image.height(), GL_BGRA, GL_UNSIGNED_BYTE, image.bits());
         //put_flog(LOG_DEBUG, "texture updated");
     }
 


### PR DESCRIPTION
Based on Qt documentation, constBits seems to be a new 4.7-only  feature. 
http://harmattan-dev.nokia.com/docs/platform-api-reference/xml/daily-docs/libqt4/qimage.html#constBits

We should be able to use QImage::bits() since the argument type for glTexSubImage2D is const anyways, right ?
http://www.opengl.org/sdk/docs/man/xhtml/glTexSubImage2D.xml
