### PR TITLE
Bugfix: if a streamer was improperly disconnected, the NetworkListenerTh...

### DIFF
--- a/src/core/NetworkListenerThread.cpp
+++ b/src/core/NetworkListenerThread.cpp
@@ -45,6 +45,8 @@
 
 #include <stdint.h>
 
+#define RECEIVE_TIMEOUT_MS  3000
+
 NetworkListenerThread::NetworkListenerThread(int socketDescriptor)
     : socketDescriptor_(socketDescriptor)
     , tcpSocket_(new QTcpSocket(this)) // Make sure that tcpSocket_ parent is *this* so it also gets moved to thread!
@@ -148,7 +150,11 @@ QByteArray NetworkListenerThread::receiveMessageBody(const int size)
 
         while(messageByteArray.size() < size)
         {
-            tcpSocket_->waitForReadyRead();
+            if (!tcpSocket_->waitForReadyRead(RECEIVE_TIMEOUT_MS))
+            {
+                emit finished();
+                return QByteArray();
+            }
 
             messageByteArray.append(tcpSocket_->read(size - messageByteArray.size()));
         }

--- a/src/dcstream/Socket.cpp
+++ b/src/dcstream/Socket.cpp
@@ -134,7 +134,8 @@ bool Socket::receive(MessageHeader & messageHeader, QByteArray & message)
 
         while(message.size() < int(messageHeader.size))
         {
-            socket_->waitForReadyRead();
+            if ( !socket_->waitForReadyRead(RECEIVE_TIMEOUT_MS) )
+                return false;
 
             message.append(socket_->read(messageHeader.size - message.size()));
         }


### PR DESCRIPTION
...read might end up in a dead loop.

Change-Id: I7c9034daa9ae4c06571039f28f160c6ca84c4a6d
