### PR TITLE
Adding new config file with placeholders, SSL ...

### DIFF
--- a/webservice/etc/nginx.conf
+++ b/webservice/etc/nginx.conf
@@ -1,13 +1,17 @@
 ####
+# WARNING! This file is not usable "as-is". It uses value placeholders
+# (${variable}) for the configuration of the FastCGI backend server and port
+# (See fastcgi_pass below).
+#
 # The following two webs provide detailed information about nginx configuration
 # directives and variables:
 #
 # http://wiki.nginx.org/HttpFcgiModule
 # http://wiki.nginx.org/HttpCoreModule
 ####
-user www-data;
+user nginx;
 worker_processes 4;
-pid /run/nginx.pid;
+pid /var/run/nginx.pid;
 
 events {
   ####
@@ -20,14 +24,30 @@ http {
   ####
   # The path to the static content root
   ####
-  root /var/www/htdocs;
+  root /var/nginx/htdocs;
   index index.html;
-  server {
-    listen 80;
 
-    set $mobile_rewrite do_not_perform;                                                                                                                                                                          
-                                                                                                                                                                                                                 
-    ## http_user_agent for mobile / smart phones ##                                                                                                                                                              
+  # Redirect HTTP requests to HTTPS
+  server {
+    listen         80;
+    rewrite        ^ https://$http_host$request_uri? permanent;
+  }
+
+  server {
+    listen 443;
+
+    # Enable SSL
+    ssl on;
+    ssl_certificate /etc/nginx/ssl/server.crt;
+    ssl_certificate_key /etc/nginx/ssl/server.key;
+
+    ####
+    # Detect when the site is accessed through mobile device, and if so redirect
+    # them to mobile specific content
+    ####
+    set $mobile_rewrite do_not_perform;
+    
+    # http_user_agent for mobile / smart phones
     if ($http_user_agent ~* "(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|netfront|opera m(ob|in)i|palm( os)?\
     |phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows (ce|phone)|xda|xiino") {
       set $mobile_rewrite perform;
@@ -45,59 +65,87 @@ http {
       set $mobile_rewrite perform;
     }
 
-    if ($request_uri ~* "(mobile/|dcapi/|scripts/)") {
+    ####
+    # Do not redirect to mobile content if the request is for mobile content (infinite loop otherewise),
+    # or for a web service api, or for javascript
+    ####
+    if ($request_uri ~* "(/wall/mobile/|/wall/dcapi/|/wall/scripts/)") {
         set $mobile_rewrite do_not_perform;
     }
 
-
-    ## redirect to m.example.com ##                                                                                                                                                                              
+    # Execute redirection to mobile content if necessary
     if ($mobile_rewrite = perform) {
-      rewrite ^ mobile$request_uri redirect;
+      rewrite ^(/wall/)(.*) /wall/mobile/$2 redirect;
       break;
     }
 
-    location ~ ^/dcapi/(.*)$ {
+    ####
+    # Requests for web services are handled here.
+    ####
+    location ~ ^/wall/dcapi/(.*)$ {
       gzip off; #gzip makes scripts feel slower since they have to complete before getting gzipped
+
       ####
-      # This is the host and port that is running the FastCGI Server
+      # This is the host and port that is running the FastCGI Server. Be aware that the value provided
+      # here is meant to be customized for your own infrastructure, and it is not usable without
+      # modification.
+      #
+      # A valid fastcgi_pass conguration line looks like the following:
+      # fastcgi_pass server_name:10000
       ####
-      fastcgi_pass 127.0.0.1:9999;
-      fastcgi_param QUERY_STRING	$query_string;
+      fastcgi_pass ${host}:${port};
+
+      fastcgi_param QUERY_STRING $query_string;
       fastcgi_param REQUEST_METHOD $request_method;
       fastcgi_param CONTENT_TYPE $content_type;
       fastcgi_param CONTENT_LENGTH $content_length;
       fastcgi_param GATEWAY_INTERFACE CGI/1.1;
       fastcgi_param SERVER_SOFTWARE nginx;
-      fastcgi_param REQUEST_URI $request_uri;
+
       ####
-      # Request without query string
+      # Transform web service request to the URL the backend expects.
+      # The /wall prefix is part of the front-end deployment, and
+      # the backend does not use that information, in fact it is
+      # completely independent of the way the front-end is deployed.
       ####
-      fastcgi_param DOCUMENT_URI	$document_uri;
+      fastcgi_param REQUEST_URI /dcapi/$1;
+      fastcgi_param DOCUMENT_URI /dcapi/$1;
+
       ####
       # Pass headers and body of request to FastCGI backend
       ####
       fastcgi_pass_request_body	on;
       fastcgi_pass_request_headers on;
+
       ####
-      # NGINX server ip and port
+      # NGINX server ip address and port
       ####
       fastcgi_param SERVER_ADDR $server_addr;
       fastcgi_param SERVER_PORT $server_port;
+
       ####
-      # Requester ip and port
+      # Requester ip address and port
       ####
       fastcgi_param REMOTE_ADDR	$remote_addr;
       fastcgi_param REMOTE_PORT $remote_port;
     }
 
-    location /mobile/ {
-      try_files $uri $uri/ /mobile/textinput.html;
-      index /mobile/textinput.html;
+    ####
+    # Handle requests for inexistent resources by serving or redirecting them to
+    # the textinput page (either mobile or desktop based on the request)
+    ####
+    location /wall/mobile/ {
+      try_files $uri $uri/ /wall/mobile/textinput.html;
+      index /wall/mobile/textinput.html;
+    } 
+
+    location /wall/ {
+      try_files $uri $uri/ /wall/textinput.html;
+      index /wall/textinput.html;
     }
 
     location / {
-      try_files $uri $uri/ /textinput.html;
-      index textinput.html;
+      rewrite ^ /wall/textinput.html redirect;
     }
   }
 }


### PR DESCRIPTION
This file now includes the use  placeholders for the configuration of the FastCGI backend server and port. It also forces the use of SSL. 

We enforce the use of SSL because one of the things that is sent via the textinput application are passwords.
