### PR TITLE
core library now needs ffmpeg include directories to build

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -3,6 +3,7 @@
 #                     Raphael Dumusc <raphael.dumusc@epfl.ch>
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+include_directories(${FFMPEG_INCLUDE_DIR})
 
 set(DCCORE_LINK_LIBRARIES dcwebservice
   ${Boost_LIBRARIES}


### PR DESCRIPTION
if ffmpeg is installed in a nonstandard location, the FFMPEG_INCLUDE_DIR needs to be passed to the core library include directories now.
