### PR TITLE
Fix tapAndHold again - don't block ongoing pan gestures

### DIFF
--- a/apps/DisplayCluster/ContentWindowTouchArea.cpp
+++ b/apps/DisplayCluster/ContentWindowTouchArea.cpp
@@ -192,12 +192,15 @@ void ContentWindowTouchArea::gestureEvent( QGestureEvent* event_ )
     {
         if( gesture->state() == Qt::GestureStarted )
             blockTapGesture_ = false;
-        else if( blockTapGesture_ )
-            return;
     }
 
     if( contentWindow_->isSelected( ))
     {
+        // After switching to interaction mode, don't send any events to
+        // the delegate until a new tap has begun
+        if( blockTapGesture_ )
+            return;
+
         contentWindow_->getInteractionDelegate().gestureEvent( event_ );
         return;
     }

--- a/apps/DisplayCluster/TouchArea.cpp
+++ b/apps/DisplayCluster/TouchArea.cpp
@@ -91,16 +91,19 @@ bool TouchArea::gestureEvent( QGestureEvent* event_ )
         // *Tap begin* ----- *TapAndHold begin* - *TapAndHold end* -- *Tap end*
         if( gesture->state() == Qt::GestureStarted )
             blockTapGesture_ = false;
-        else if( blockTapGesture_ )
-            return false;
-
-        event_->accept( Qt::TapGesture );
-        if( gesture->state() == Qt::GestureFinished )
+        // Only block tap gesture, but let other gestures (like pan) continue
+        // In some cases, they may have been in progress before the tapAndHold
+        // happend
+        if( !blockTapGesture_ )
         {
-            QTapGesture* tapGesture = static_cast<QTapGesture*>( gesture );
-            emit tap( tapGesture->position( ));
+            event_->accept( Qt::TapGesture );
+            if( gesture->state() == Qt::GestureFinished )
+            {
+                QTapGesture* tapGesture = static_cast<QTapGesture*>( gesture );
+                emit tap( tapGesture->position( ));
+            }
+            return true;
         }
-        return true;
     }
     if(( gesture = event_->gesture( PanGestureRecognizer::type( ))))
     {


### PR DESCRIPTION
This happend in a tricky situation when a tapAndHold was detected while both a tap and a pan gesture were already ongoing. Then, everything was blocked. and the pan could not finish and the window remained in "moving" state, even though it did not move anymore...