### PR TITLE
Fix OSX build  use ';' after BOOST_GLOBAL_FIXTURE

### DIFF
--- a/tests/cpp/core/StateSerializationTests.cpp
+++ b/tests/cpp/core/StateSerializationTests.cpp
@@ -63,7 +63,7 @@ namespace ut = boost::unit_test;
 
 // QCoreApplication is required by QtXml for loading legacy configuration files
 #include "MinimalGlobalQtApp.h"
-BOOST_GLOBAL_FIXTURE( MinimalGlobalQtApp )
+BOOST_GLOBAL_FIXTURE( MinimalGlobalQtApp );
 
 namespace
 {


### PR DESCRIPTION
this was left out with dcdd6037bc013209b109cbfc128d6c3c3f1217b0