### PR TITLE
Correctly release MPI request data in MPINospin send/recv

### DIFF
--- a/dc/core/MPINospin.cpp
+++ b/dc/core/MPINospin.cpp
@@ -86,7 +86,7 @@ int MPI_Send_Nospin( void *buff, const int count, MPI_Datatype datatype,
         PMPI_Request_get_status( req, &flag, &status );
     }
 
-    return status.MPI_ERROR;
+    return MPI_Wait( &req, &status );
 }
 
 int MPI_Recv_Nospin( void* buff, const int count, MPI_Datatype datatype,
@@ -105,5 +105,5 @@ int MPI_Recv_Nospin( void* buff, const int count, MPI_Datatype datatype,
         PMPI_Request_get_status( req, &flag, status );
     }
 
-    return status->MPI_ERROR;
+    return MPI_Wait( &req, status );
 }


### PR DESCRIPTION
This fixes a serious increase in the memory usage which could exhaust
system resources over time. It also attenuates the likelihood of
[DISCL-319] bug, observed with openmpi when forking a 'localstreamer'
process.