### PR TITLE
Simplify DisplayGroupView on master process

### DIFF
--- a/apps/DisplayCluster/DisplayGroupView.h
+++ b/apps/DisplayCluster/DisplayGroupView.h
@@ -59,14 +59,13 @@ class DisplayGroupView : public QQuickView
 
 public:
     /** Constructor. */
-    DisplayGroupView( OptionsPtr options );
+    DisplayGroupView( OptionsPtr options, const MasterConfiguration& config );
 
     /** Destructor */
     virtual ~DisplayGroupView();
 
     /** Set the DisplayGroup model that this view should present. */
-    void setDataModel( DisplayGroupPtr displayGroup, const QSize& numberOfTiles,
-                       int mullionWidth );
+    void setDataModel( DisplayGroupPtr displayGroup );
 
     /** Get the control panel in this view. */
     QmlControlPanel& getControlPanel();
@@ -79,11 +78,8 @@ signals:
     void backgroundTapAndHold( QPointF pos );
 
 protected:
-    /** @name Re-implemented QWindow events */
-    //@{
+    /** Re-implement QWindow event to capture tab key. */
     bool event( QEvent* event ) override;
-    void resizeEvent( QResizeEvent* event ) override;
-    //@}
 
 private slots:
     void add( ContentWindowPtr contentWindow );

--- a/apps/DisplayCluster/MasterWindow.cpp
+++ b/apps/DisplayCluster/MasterWindow.cpp
@@ -75,7 +75,7 @@ MasterWindow::MasterWindow( DisplayGroupPtr displayGroup,
     , _options( new Options )
     , _backgroundWidget( new BackgroundWidget( config, this ))
     , _webbrowserWidget( new WebbrowserWidget( config, this ))
-    , _displayGroupView( new DisplayGroupView( _options ))
+    , _displayGroupView( new DisplayGroupView( _options, config ))
     , _autoFocusPixelStreamsAction( 0 )
     , _contentFolder( config.getDockStartDir( ))
     , _sessionFolder( config.getDockStartDir( ))
@@ -94,7 +94,7 @@ MasterWindow::MasterWindow( DisplayGroupPtr displayGroup,
     resize( DEFAULT_WINDOW_SIZE );
     setAcceptDrops( true );
 
-    _setupMasterWindowUI( config );
+    _setupMasterWindowUI();
 
     show();
 }
@@ -116,7 +116,7 @@ QAction* MasterWindow::getAutoFocusPixelStreamsAction()
     return _autoFocusPixelStreamsAction;
 }
 
-void MasterWindow::_setupMasterWindowUI( const MasterConfiguration& config )
+void MasterWindow::_setupMasterWindowUI()
 {
     // create menus in menu bar
     QMenu* fileMenu = menuBar()->addMenu("&File");
@@ -298,10 +298,7 @@ void MasterWindow::_setupMasterWindowUI( const MasterConfiguration& config )
     setCentralWidget(mainWidget);
 
     // add the local renderer group
-    _displayGroupView->setDataModel( _displayGroup, QSize(
-                                     config.getTotalScreenCountX(),
-                                     config.getTotalScreenCountY( )),
-                                     config.getMullionWidth( ));
+    _displayGroupView->setDataModel( _displayGroup );
     QWidget* wrapper = QWidget::createWindowContainer( _displayGroupView,
                                                        mainWidget );
     mainWidget->addTab( wrapper, "Display group 0" );

--- a/apps/DisplayCluster/MasterWindow.h
+++ b/apps/DisplayCluster/MasterWindow.h
@@ -114,7 +114,7 @@ private slots:
     void openAboutWidget();
 
 private:
-    void _setupMasterWindowUI( const MasterConfiguration& config );
+    void _setupMasterWindowUI();
 
     void _addContentDirectory( const QString& directoryName,
                               unsigned int gridX = 0, unsigned int gridY = 0 );

--- a/apps/DisplayCluster/resources/DisplayGroupBackground.qml
+++ b/apps/DisplayCluster/resources/DisplayGroupBackground.qml
@@ -1,4 +1,6 @@
 import QtQuick 2.0
 
 Item{
+    Wall {
+    }
 }

--- a/apps/DisplayCluster/resources/MasterContentWindow.qml
+++ b/apps/DisplayCluster/resources/MasterContentWindow.qml
@@ -6,7 +6,6 @@ import "qrc:/qml/core/style.js" as Style
 
 BaseContentWindow {
     id: windowRect
-    objectName: "MasterContentWindow"
     color: "#80000000"
 
     function closeWindow() {

--- a/apps/DisplayCluster/resources/MasterDisplayGroup.qml
+++ b/apps/DisplayCluster/resources/MasterDisplayGroup.qml
@@ -7,44 +7,6 @@ import "qrc:/qml/core/style.js" as Style
 DisplayGroup {
     id: dispGroup
     showFocusContext: false
-    layer.enabled: true
-    layer.mipmap: true
-    layer.smooth: true
-
-    property int numberOfTilesX: 1
-    property int numberOfTilesY: 1
-    property int mullionWidth: 0
-
-    property int screenWidth: (displaygroup.width - ((numberOfTilesX - 1)
-                              * mullionWidth)) / numberOfTilesX
-    property int screenHeight: (displaygroup.height - ((numberOfTilesY - 1)
-                               * mullionWidth)) / numberOfTilesY
-
-    property bool higherAspectRatio: (view.width / view.height) >
-                                     (displaygroup.width / displaygroup.height)
-
-    property int marginWidth: higherAspectRatio ? 0 : (displaygroup.width
-                              * Style.masterWindowMarginFactor)
-    property int marginHeight: higherAspectRatio ? (displaygroup.height
-                               * Style.masterWindowMarginFactor): 0
-
-    property int offsetX: higherAspectRatio ? ( view.width - displaygroup.width
-                          * scale ) / 2.0 : displaygroup.width
-                          * Style.masterWindowMarginFactor * scale / 2.0
-    property int offsetY: higherAspectRatio ? displaygroup.height
-                          * Style.masterWindowMarginFactor* scale / 2.0
-                          : ( view.height - displaygroup.height * scale ) / 2.0
-
-    property int totalWidth: displaygroup.width + (2 * mullionWidth)
-                             + marginWidth
-    property int totalHeight: displaygroup.height + (2 * mullionWidth)
-                              + marginHeight
-
-    property real scale: higherAspectRatio ? (view.height / totalHeight)
-                                           : (view.width / totalWidth)
-
-    width: displaygroup.width + 2 * mullionWidth
-    height: displaygroup.height + 2 * mullionWidth
 
     TouchArea {
         z: controlPanel.z - 1
@@ -69,47 +31,6 @@ DisplayGroup {
                     var position = Qt.point(absPos.x, absPos.y)
                     cppcontrolpanel.processAction(action, position)
                 }
-            }
-        }
-    }
-
-    Rectangle {
-        color: Style.masterWindowBezelsColor
-        width: displaygroup.width + 2 * mullionWidth
-        height: displaygroup.height + 2 * mullionWidth
-    }
-
-    transform: [
-        Scale {
-            xScale: scale
-            yScale: scale
-        },
-        Translate {
-            x : offsetX
-            y : offsetY
-        }
-    ]
-
-    Grid
-    {
-        x: mullionWidth
-        y: mullionWidth
-        columns: numberOfTilesX
-        rows: numberOfTilesY
-        spacing: mullionWidth
-        Repeater {
-            layer.mipmap: true
-            id: screens
-            model: numberOfTilesX * numberOfTilesY
-            delegate: Rectangle {
-                //Generalized checker pattern computation
-                color: ((index%2 == 0) ^
-                       (!(Math.floor(index / numberOfTilesX)%2 == 0)
-                       && (numberOfTilesX%2 == 0))) ?
-                       Style.masterWindowFirstCheckerColor
-                       : Style.masterWindowSecondCheckerColor
-                width: screenWidth
-                height: screenHeight
             }
         }
     }

--- a/apps/DisplayCluster/resources/Wall.qml
+++ b/apps/DisplayCluster/resources/Wall.qml
@@ -1,0 +1,73 @@
+import QtQuick 2.0
+import "qrc:/qml/core/style.js" as Style
+
+Rectangle {
+    objectName: "Wall"
+    color: Style.masterWindowBezelsColor
+    width: wallWidth
+    height: wallHeight
+
+    // These properties are input from the c++ Configuration class
+    property int numberOfTilesX: 1
+    property int numberOfTilesY: 1
+    property int mullionWidth: 0
+    property int mullionHeight: 0
+    property int screenWidth: 640
+    property int screenHeight: 480
+    property int wallWidth: 640
+    property int wallHeight: 480
+
+    // Grid of screens that form the wall
+    Grid {
+        columns: numberOfTilesX
+        rows: numberOfTilesY
+        columnSpacing: mullionWidth
+        rowSpacing: mullionHeight
+        Repeater {
+            model: numberOfTilesX * numberOfTilesY
+            delegate: Rectangle {
+                // Generalized checker pattern computation
+                color: ((index%2 == 0) ^
+                       (!(Math.floor(index / numberOfTilesX)%2 == 0)
+                       && (numberOfTilesX%2 == 0))) ?
+                       Style.masterWindowFirstCheckerColor :
+                       Style.masterWindowSecondCheckerColor
+                width: screenWidth
+                height: screenHeight
+            }
+        }
+    }
+
+    // Center and scale the wall (+ its child DisplayGroup) into the Qml view
+    property bool higherAspectRatio: (view.width / view.height) >
+                                     (wallWidth / wallHeight)
+
+    property int marginWidth: higherAspectRatio ? 0 : (wallWidth
+                              * Style.masterWindowMarginFactor)
+    property int marginHeight: higherAspectRatio ? (wallHeight
+                               * Style.masterWindowMarginFactor): 0
+
+    property int totalWidth: wallWidth + marginWidth
+    property int totalHeight: wallHeight + marginHeight
+
+    property real scale: higherAspectRatio ? (view.height / totalHeight)
+                                           : (view.width / totalWidth)
+
+    property int offsetX: higherAspectRatio ? ( view.width - wallWidth
+                          * scale ) / 2.0 : wallWidth
+                          * Style.masterWindowMarginFactor * scale / 2.0
+    property int offsetY: higherAspectRatio ? wallHeight
+                          * Style.masterWindowMarginFactor* scale / 2.0
+                          : ( view.height - wallHeight * scale ) / 2.0
+
+    transform: [
+        Scale {
+            xScale: scale
+            yScale: scale
+        },
+        Translate {
+            x : offsetX
+            y : offsetY
+        }
+    ]
+}

--- a/apps/DisplayCluster/resources/displaycluster.qrc
+++ b/apps/DisplayCluster/resources/displaycluster.qrc
@@ -5,6 +5,7 @@
         <file>ContentWindowButton.qml</file>
         <file>MasterDisplayGroup.qml</file>
         <file>DisplayGroupBackground.qml</file>
+        <file>Wall.qml</file>
     </qresource>
     <qresource prefix="/img/master">
         <file>close.svg</file>


### PR DESCRIPTION
This decouples the rendering of the background wall displays (fixed at startup time, read from configuration) from the DisplayGroup.