### PR TITLE
Implement generic visibility / occlusion update step

### DIFF
--- a/apps/DisplayCluster/resources/MasterContentWindow.qml
+++ b/apps/DisplayCluster/resources/MasterContentWindow.qml
@@ -57,8 +57,8 @@ BaseContentWindow {
         anchors.bottom: parent.bottom
         anchors.bottomMargin: windowRect.border.width
         anchors.horizontalCenter: parent.horizontalCenter
-        width: parent.width - 2 * windowRect.border.width
-        height: parent.height - windowRect.border.width - (titleBar.visible ? titleBar.height : windowRect.border.width)
+        width: parent.width - windowRect.widthOffset
+        height: parent.height - windowRect.heightOffset
 
         function removeOffset(position) {
             // C++ interaction delegates don't have any knowledge of the title

--- a/dc/core/BasicSynchronizer.cpp
+++ b/dc/core/BasicSynchronizer.cpp
@@ -46,9 +46,11 @@ BasicSynchronizer::BasicSynchronizer()
     _tiles.push_back( new Tile( -1, QRect(), this, true ));
 }
 
-void BasicSynchronizer::update( const ContentWindow& window )
+void BasicSynchronizer::update( const ContentWindow& window,
+                                const QRectF& visibleArea )
 {
     Q_UNUSED( window );
+    Q_UNUSED( visibleArea );
 }
 
 QString BasicSynchronizer::getSourceParams() const

--- a/dc/core/BasicSynchronizer.h
+++ b/dc/core/BasicSynchronizer.h
@@ -55,7 +55,8 @@ public:
     BasicSynchronizer();
 
     /** @copydoc ContentSynchronizer::update */
-    void update( const ContentWindow& window ) override;
+    void update( const ContentWindow& window,
+                 const QRectF& visibleArea ) override;
 
     /** @copydoc ContentSynchronizer::getSourceParams */
     QString getSourceParams() const override;

--- a/dc/core/CMakeLists.txt
+++ b/dc/core/CMakeLists.txt
@@ -86,6 +86,7 @@ list(APPEND DCCORE_PUBLIC_HEADERS
   TestPattern.h
   TextureContent.h
   TextureProvider.h
+  VisibilityHelper.h
   ZoomInteractionDelegate.h
   ZoomHelper.h
   configuration/Configuration.h
@@ -218,6 +219,7 @@ list(APPEND DCCORE_SOURCES
   TextureContent.cpp
   TextureProvider.cpp
   VectorialSynchronizer.cpp
+  VisibilityHelper.cpp
   WallFromMasterChannel.cpp
   WallToMasterChannel.cpp
   WallToWallChannel.cpp

--- a/dc/core/ContentSynchronizer.h
+++ b/dc/core/ContentSynchronizer.h
@@ -71,7 +71,8 @@ public:
     virtual ~ContentSynchronizer();
 
     /** Update the Content. */
-    virtual void update( const ContentWindow& window ) = 0;
+    virtual void update( const ContentWindow& window,
+                         const QRectF& visibleArea ) = 0;
 
     /** Get the additional source parameters. */
     virtual QString getSourceParams() const = 0;
@@ -90,8 +91,7 @@ public:
 
     /** @return a ContentSynchronizer for the given content. */
     static ContentSynchronizerPtr create( ContentPtr content,
-                                          QQmlImageProviderBase& provider,
-                                          const QRect& screenRect );
+                                          QQmlImageProviderBase& provider );
 
 signals:
     /** Notifier for the sourceParams property. */

--- a/dc/core/DisplayGroupRenderer.cpp
+++ b/dc/core/DisplayGroupRenderer.cpp
@@ -44,6 +44,7 @@
 #include "ContentWindowController.h"
 #include "Options.h"
 #include "Markers.h"
+#include "VisibilityHelper.h"
 #include "WallWindow.h"
 
 #include <deflect/Frame.h>
@@ -116,7 +117,8 @@ void DisplayGroupRenderer::setDisplayGroup( DisplayGroupPtr displayGroup )
         if( !_windowItems.contains( id ))
             _createWindowQmlItem( window );
 
-        _windowItems[id]->update( window );
+        const VisibilityHelper helper( *displayGroup, _screenRect );
+        _windowItems[id]->update( window, helper.getVisibleArea( *window ));
         _windowItems[id]->setStackingOrder( stackingOrder++ );
     }
 
@@ -169,7 +171,7 @@ void DisplayGroupRenderer::_createWindowQmlItem( ContentWindowPtr window )
 {
     const QUuid& id = window->getID();
     _windowItems[id].reset( new QmlWindowRenderer( _engine, *_displayGroupItem,
-                                                   window, _screenRect ));
+                                                   window ));
     emit windowAdded( _windowItems[id] );
 }
 
@@ -197,7 +199,7 @@ void DisplayGroupRenderer::_setBackground( ContentPtr content )
     window->getController()->adjustSize( SIZE_FULLSCREEN );
     _backgroundWindowItem.reset( new QmlWindowRenderer( _engine,
                                                         *_displayGroupItem,
-                                                        window, _screenRect,
+                                                        window,
                                                         true ));
     _backgroundWindowItem->setStackingOrder( BACKGROUND_STACKING_ORDER );
 }

--- a/dc/core/DynamicTextureSynchronizer.h
+++ b/dc/core/DynamicTextureSynchronizer.h
@@ -54,14 +54,13 @@ class DynamicTextureSynchronizer : public ContentSynchronizer
 
 public:
     /** Constructor */
-    DynamicTextureSynchronizer( const QString& uri,
-                                const QRect& screenRect,
-                                TextureProvider& provider );
+    DynamicTextureSynchronizer( const QString& uri, TextureProvider& provider );
 
     ~DynamicTextureSynchronizer();
 
     /** @copydoc ContentSynchronizer::updateTiles */
-    void update( const ContentWindow& window ) override;
+    void update( const ContentWindow& window,
+                 const QRectF& visibleArea ) override;
 
     /** @copydoc ContentSynchronizer::getSourceParams */
     QString getSourceParams() const override;
@@ -84,7 +83,6 @@ private:
     Tiles _tiles;
     DynamicTexturePtr _reader;
     uint _lod;
-    const QRectF _screenRect;
     QRectF _visibleArea;
 
     void _updateTiles( const QRectF& visibleArea, uint lod );

--- a/dc/core/MovieSynchronizer.cpp
+++ b/dc/core/MovieSynchronizer.cpp
@@ -60,8 +60,10 @@ MovieSynchronizer::~MovieSynchronizer()
     _provider.close( _uri );
 }
 
-void MovieSynchronizer::update( const ContentWindow& window )
+void MovieSynchronizer::update( const ContentWindow& window,
+                                const QRectF& visibleArea )
 {
+    Q_UNUSED( visibleArea );
     _updater->sync( static_cast< const MovieContent& >( *window.getContent( )));
 }
 

--- a/dc/core/MovieSynchronizer.h
+++ b/dc/core/MovieSynchronizer.h
@@ -67,7 +67,8 @@ public:
     ~MovieSynchronizer();
 
     /** @copydoc ContentSynchronizer::update */
-    void update( const ContentWindow& window ) override;
+    void update( const ContentWindow& window,
+                 const QRectF& visibleArea ) override;
 
     /** @copydoc ContentSynchronizer::getSourceParams */
     QString getSourceParams() const override;

--- a/dc/core/PixelStreamSynchronizer.cpp
+++ b/dc/core/PixelStreamSynchronizer.cpp
@@ -61,9 +61,11 @@ PixelStreamSynchronizer::~PixelStreamSynchronizer()
     _provider.close( _uri );
 }
 
-void PixelStreamSynchronizer::update( const ContentWindow& window )
+void PixelStreamSynchronizer::update( const ContentWindow& window,
+                                      const QRectF& visibleArea )
 {
     Q_UNUSED( window );
+    _updater->updateTilesVisibility( visibleArea );
 }
 
 QString PixelStreamSynchronizer::getSourceParams() const

--- a/dc/core/PixelStreamSynchronizer.h
+++ b/dc/core/PixelStreamSynchronizer.h
@@ -69,8 +69,9 @@ public:
     /** Destruct the synchronizer and close the stream in the provider. */
     ~PixelStreamSynchronizer();
 
-    /** @copydoc ContentSynchronizer::updateTiles */
-    void update( const ContentWindow& window ) override;
+    /** @copydoc ContentSynchronizer::update */
+    void update( const ContentWindow& window,
+                 const QRectF& visibleArea ) override;
 
     /** @copydoc ContentSynchronizer::getSourceParams */
     QString getSourceParams() const override;

--- a/dc/core/PixelStreamUpdater.cpp
+++ b/dc/core/PixelStreamUpdater.cpp
@@ -101,6 +101,11 @@ void PixelStreamUpdater::updatePixelStream( deflect::FramePtr frame )
     _swapSyncFrame.update( frame );
 }
 
+void PixelStreamUpdater::updateTilesVisibility( const QRectF& visibleArea )
+{
+    Q_UNUSED( visibleArea );
+}
+
 void PixelStreamUpdater::_onFrameSwapped( deflect::FramePtr frame )
 {
     std::sort( frame->segments.begin(), frame->segments.end(),

--- a/dc/core/PixelStreamUpdater.h
+++ b/dc/core/PixelStreamUpdater.h
@@ -72,6 +72,9 @@ public:
     /** Get the list of tiles for use by QML repeater. */
     const Tiles& getTiles() const;
 
+    /** Update the tiles visibility given the visible area of the window. */
+    void updateTilesVisibility( const QRectF& visibleArea );
+
 public slots:
     /** Update the appropriate PixelStream with the given frame. */
     void updatePixelStream( deflect::FramePtr frame );

--- a/dc/core/QmlWindowRenderer.cpp
+++ b/dc/core/QmlWindowRenderer.cpp
@@ -52,7 +52,6 @@ const QUrl QML_WINDOW_URL( "qrc:/qml/core/WallContentWindow.qml" );
 QmlWindowRenderer::QmlWindowRenderer( QQmlEngine& engine,
                                       QQuickItem& parentItem,
                                       ContentWindowPtr contentWindow,
-                                      const QRect& screenRect,
                                       const bool isBackground )
     : _contentWindow( contentWindow )
     , _windowContext( new QQmlContext( engine.rootContext( )))
@@ -62,7 +61,7 @@ QmlWindowRenderer::QmlWindowRenderer( QQmlEngine& engine,
 
     auto content = _contentWindow->getContent();
     auto provider = engine.imageProvider( content->getProviderId( ));
-    _contentSynchronizer = ContentSynchronizer::create( content, *provider, screenRect );
+    _contentSynchronizer = ContentSynchronizer::create( content, *provider );
     _windowContext->setContextProperty( "contentsync",
                                         _contentSynchronizer.get( ));
 
@@ -76,12 +75,13 @@ QmlWindowRenderer::~QmlWindowRenderer()
     delete _windowItem;
 }
 
-void QmlWindowRenderer::update( ContentWindowPtr contentWindow )
+void QmlWindowRenderer::update( ContentWindowPtr contentWindow,
+                                const QRectF& visibleArea )
 {
     // Could be optimized by checking for changes before updating the context
     _windowContext->setContextProperty( "contentwindow", contentWindow.get( ));
     _contentWindow = contentWindow;
-    _contentSynchronizer->update( *_contentWindow );
+    _contentSynchronizer->update( *_contentWindow, visibleArea );
 }
 
 void QmlWindowRenderer::setStackingOrder( const int value )

--- a/dc/core/QmlWindowRenderer.h
+++ b/dc/core/QmlWindowRenderer.h
@@ -56,14 +56,14 @@ public:
     QmlWindowRenderer( QQmlEngine& engine,
                        QQuickItem& parentItem,
                        ContentWindowPtr contentWindow,
-                       const QRect& screenRect,
                        bool isBackground = false );
     /** Destructor. */
     ~QmlWindowRenderer();
 
     /** Update the qml object with a new data model. */
-    void update( ContentWindowPtr contentWindow );
+    void update( ContentWindowPtr contentWindow, const QRectF& visibleArea );
 
+    /** Set the z value of the window. */
     void setStackingOrder( int value );
 
     /** Get the ContentWindow. */

--- a/dc/core/VectorialSynchronizer.cpp
+++ b/dc/core/VectorialSynchronizer.cpp
@@ -42,8 +42,11 @@
 #include "ContentWindow.h"
 #include "ImageProviderStringifier.h"
 
-void VectorialSynchronizer::update( const ContentWindow& window )
+void VectorialSynchronizer::update( const ContentWindow& window,
+                                    const QRectF& visibleArea )
 {
+    Q_UNUSED( visibleArea );
+
     // Legacy solution. A list of tiles with different LODs might bring
     // better interactive performances and allow for texture caching.
     ContentPtr content = window.getContent();

--- a/dc/core/VectorialSynchronizer.h
+++ b/dc/core/VectorialSynchronizer.h
@@ -55,7 +55,8 @@ public:
     VectorialSynchronizer() = default;
 
     /** @copydoc ContentSynchronizer::update */
-    void update( const ContentWindow& window ) override;
+    void update( const ContentWindow& window,
+                 const QRectF& visibleArea ) override;
 
     /** @copydoc ContentSynchronizer::getSourceParams */
     QString getSourceParams() const override;

--- a/dc/core/VisibilityHelper.h
+++ b/dc/core/VisibilityHelper.h
@@ -1,5 +1,5 @@
 /*********************************************************************/
-/* Copyright (c) 2015, EPFL/Blue Brain Project                       */
+/* Copyright (c) 2016, EPFL/Blue Brain Project                       */
 /*                     Raphael Dumusc <raphael.dumusc@epfl.ch>       */
 /* All rights reserved.                                              */
 /*                                                                   */
@@ -37,41 +37,25 @@
 /* or implied, of The University of Texas at Austin.                 */
 /*********************************************************************/
 
-#include "ContentSynchronizer.h"
+#ifndef VISIBILITYHELPER_H
+#define VISIBILITYHELPER_H
 
-#include "Content.h"
+#include "types.h"
 
-#include "BasicSynchronizer.h"
-#include "DynamicTextureSynchronizer.h"
-#include "MovieSynchronizer.h"
-#include "PixelStreamSynchronizer.h"
-#include "VectorialSynchronizer.h"
-
-#include "MovieProvider.h"
-#include "PixelStreamProvider.h"
-#include "TextureProvider.h"
-
-ContentSynchronizer::~ContentSynchronizer() {}
-
-ContentSynchronizerPtr
-ContentSynchronizer::create( ContentPtr content,
-                             QQmlImageProviderBase& provider )
+/**
+ * Helper to determine the visible parts of windows on the wall.
+ */
+class VisibilityHelper
 {
-    switch( content->getType( ))
-    {
-    case CONTENT_TYPE_DYNAMIC_TEXTURE:
-        return make_unique<DynamicTextureSynchronizer>(
-                 content->getURI(), dynamic_cast<TextureProvider&>( provider ));
-    case CONTENT_TYPE_MOVIE:
-        return make_unique<MovieSynchronizer>(
-                   content->getURI(), dynamic_cast<MovieProvider&>( provider ));
-    case CONTENT_TYPE_PIXEL_STREAM:
-        return make_unique<PixelStreamSynchronizer>(
-             content->getURI(), dynamic_cast<PixelStreamProvider&>( provider ));
-    case CONTENT_TYPE_PDF:
-    case CONTENT_TYPE_SVG:
-        return make_unique<VectorialSynchronizer>();
-    default:
-        return make_unique<BasicSynchronizer>();
-    }
-}
+public:
+    VisibilityHelper( const DisplayGroup& displayGroup,
+                      const QRect& visibleArea );
+
+    QRectF getVisibleArea( const ContentWindow& window ) const;
+
+private:
+    const DisplayGroup& _displayGroup;
+    const QRect& _visibleArea;
+};
+
+#endif

--- a/dc/core/resources/BaseContentWindow.qml
+++ b/dc/core/resources/BaseContentWindow.qml
@@ -10,17 +10,20 @@ Rectangle {
     property bool isBackground: false
     property bool animating: widthAnimation.running || heightAnimation.running
                              || unfocusTransition.running
-    property real heightOffset: titleBar.visible ? titleBar.height : 0
-    property real yOffset: isBackground ? 0.0 : 0.5 * heightOffset
+
+    property real widthOffset: 2 * border.width
+    property real heightOffset: border.width + (titleBar.visible ? titleBar.height : border.width)
+    property real xOffset: border.width
+    property real yOffset: titleBar.visible ? titleBar.height : border.width
 
     border.color: Style.windowBorderDefaultColor
     border.width: options.showWindowBorders && !isBackground ? Style.windowBorderWidth : 0
 
-    x: contentwindow.x
+    x: contentwindow.x - xOffset
     y: contentwindow.y - yOffset
     z: stackingOrder
-    width: contentwindow.width + 2 * border.width
-    height: contentwindow.height + heightOffset + 2 * border.width
+    width: contentwindow.width + widthOffset
+    height: contentwindow.height + heightOffset
 
     Rectangle {
         id: titleBar
@@ -50,9 +53,9 @@ Rectangle {
             when: contentwindow.focused
             PropertyChanges {
                 target: windowRect
-                x: contentwindow.focusedCoordinates.x
+                x: contentwindow.focusedCoordinates.x - xOffset
                 y: contentwindow.focusedCoordinates.y - yOffset
-                width: contentwindow.focusedCoordinates.width
+                width: contentwindow.focusedCoordinates.width + widthOffset
                 height: contentwindow.focusedCoordinates.height + heightOffset
                 border.color: Style.windowBorderSelectedColor
                 z: stackingOrder + Style.focusZorder

--- a/tests/cpp/core/VisibilityHelperTests.cpp
+++ b/tests/cpp/core/VisibilityHelperTests.cpp
@@ -1,0 +1,187 @@
+/*********************************************************************/
+/* Copyright (c) 2016, EPFL/Blue Brain Project                       */
+/*                     Raphael Dumusc <raphael.dumusc@epfl.ch>       */
+/* All rights reserved.                                              */
+/*                                                                   */
+/* Redistribution and use in source and binary forms, with or        */
+/* without modification, are permitted provided that the following   */
+/* conditions are met:                                               */
+/*                                                                   */
+/*   1. Redistributions of source code must retain the above         */
+/*      copyright notice, this list of conditions and the following  */
+/*      disclaimer.                                                  */
+/*                                                                   */
+/*   2. Redistributions in binary form must reproduce the above      */
+/*      copyright notice, this list of conditions and the following  */
+/*      disclaimer in the documentation and/or other materials       */
+/*      provided with the distribution.                              */
+/*                                                                   */
+/*    THIS  SOFTWARE IS PROVIDED  BY THE  UNIVERSITY OF  TEXAS AT    */
+/*    AUSTIN  ``AS IS''  AND ANY  EXPRESS OR  IMPLIED WARRANTIES,    */
+/*    INCLUDING, BUT  NOT LIMITED  TO, THE IMPLIED  WARRANTIES OF    */
+/*    MERCHANTABILITY  AND FITNESS FOR  A PARTICULAR  PURPOSE ARE    */
+/*    DISCLAIMED.  IN  NO EVENT SHALL THE UNIVERSITY  OF TEXAS AT    */
+/*    AUSTIN OR CONTRIBUTORS BE  LIABLE FOR ANY DIRECT, INDIRECT,    */
+/*    INCIDENTAL,  SPECIAL, EXEMPLARY,  OR  CONSEQUENTIAL DAMAGES    */
+/*    (INCLUDING, BUT  NOT LIMITED TO,  PROCUREMENT OF SUBSTITUTE    */
+/*    GOODS  OR  SERVICES; LOSS  OF  USE,  DATA,  OR PROFITS;  OR    */
+/*    BUSINESS INTERRUPTION) HOWEVER CAUSED  AND ON ANY THEORY OF    */
+/*    LIABILITY, WHETHER  IN CONTRACT, STRICT  LIABILITY, OR TORT    */
+/*    (INCLUDING NEGLIGENCE OR OTHERWISE)  ARISING IN ANY WAY OUT    */
+/*    OF  THE  USE OF  THIS  SOFTWARE,  EVEN  IF ADVISED  OF  THE    */
+/*    POSSIBILITY OF SUCH DAMAGE.                                    */
+/*                                                                   */
+/* The views and conclusions contained in the software and           */
+/* documentation are those of the authors and should not be          */
+/* interpreted as representing official policies, either expressed   */
+/* or implied, of The University of Texas at Austin.                 */
+/*********************************************************************/
+
+
+#define BOOST_TEST_MODULE VisibilityHelperTests
+#include <boost/test/unit_test.hpp>
+namespace ut = boost::unit_test;
+
+#include "VisibilityHelper.h"
+#include "DisplayGroup.h"
+#include "ContentWindow.h"
+
+#include "DummyContent.h"
+
+#include <boost/make_shared.hpp>
+
+namespace
+{
+const QSize groupSize( 800, 600 );
+const QSize size( 200, 200 );
+const QRect viewRect( 0, 0, groupSize.width() / 2, groupSize.height( ));
+const QRect centeredViewRect( 350, 250, 100, 100 );
+}
+
+struct Fixture {
+    Fixture()
+        : group( new DisplayGroup( groupSize ))
+        , content( new DummyContent )
+        , helper( *group, viewRect )
+    {
+        content->setDimensions( size );
+        window = boost::make_shared<ContentWindow>( content );
+
+        group->setShowWindowTitles( false );
+        group->addContentWindow( window );
+
+        BOOST_REQUIRE_EQUAL( window->getCoordinates(),
+                             QRectF( QPointF( 0, 0 ), size ));
+    }
+
+    DisplayGroupPtr group;
+    ContentPtr content;
+    ContentWindowPtr window;
+    VisibilityHelper helper;
+};
+
+BOOST_FIXTURE_TEST_CASE( testSingleWindow, Fixture )
+{
+    const QRectF& coord = window->getCoordinates();
+
+    // Fully inside
+    BOOST_CHECK_EQUAL( helper.getVisibleArea( *window ), coord );
+
+    // Fully outside
+    window->setCoordinates( QRectF( QPointF( 400, 0 ), size ));
+    BOOST_CHECK_EQUAL( helper.getVisibleArea( *window ), QRectF( ));
+
+    // Half-inside horizonally
+    window->setCoordinates( QRectF( QPointF( 300, 0 ), size ));
+    BOOST_CHECK_EQUAL( helper.getVisibleArea( *window ),
+                       QRectF( QPointF( 0, 0 ), QSize( 100, 200 )));
+
+    window->setCoordinates( QRectF( QPointF( -100, 0 ), size ));
+    BOOST_CHECK_EQUAL( helper.getVisibleArea( *window ),
+                       QRectF( QPointF( 100, 0 ), QSize( 100, 200 )));
+
+    // Half-inside vertically, bottom cut
+    window->setCoordinates( QRectF( QPointF( 0, 500 ), size ));
+    BOOST_CHECK_EQUAL( helper.getVisibleArea( *window ),
+                       QRectF( QPointF( 0, 0 ), QSize( 200, 100 )));
+
+    // Half-inside vertically, top cut
+    window->setCoordinates( QRectF( QPointF( 0, -100 ), size ));
+    BOOST_CHECK_EQUAL( helper.getVisibleArea( *window ),
+                       QRectF( QPointF( 0, 100 ), QSize( 200, 100 )));
+
+    // Corner view cut
+    window->setCoordinates( QRectF( QPointF( 300, 500 ), size ));
+    BOOST_CHECK_EQUAL( helper.getVisibleArea( *window ),
+                       QRectF( QPointF( 0, 0 ), QSize( 100, 100 )));
+}
+
+BOOST_FIXTURE_TEST_CASE( testSingleWindowCenteredViewRect, Fixture )
+{
+    window->setCoordinates( QRectF( QPointF( 300, 200 ), size ));
+
+    VisibilityHelper otherViewRectHelper( *group, centeredViewRect );
+    BOOST_CHECK_EQUAL( otherViewRectHelper.getVisibleArea( *window ),
+                       QRectF( QPointF( 50, 50 ), centeredViewRect.size( )));
+}
+
+BOOST_FIXTURE_TEST_CASE( testOverlappingWindow, Fixture )
+{
+    const QRectF& coord = window->getCoordinates();
+    BOOST_REQUIRE_EQUAL( helper.getVisibleArea( *window ), coord );
+
+    ContentWindowPtr otherWindow = boost::make_shared<ContentWindow>( content );
+    group->addContentWindow( otherWindow );
+
+    // Full overlap
+    BOOST_CHECK_EQUAL( helper.getVisibleArea( *window ), QRectF( ));
+
+    // Half-above horizonally
+    otherWindow->setCoordinates( QRectF( QPointF( 100, 0 ), size ));
+    BOOST_CHECK_EQUAL( helper.getVisibleArea( *window ),
+                       QRectF( QPointF( 0, 0 ), QSize( 100, 200 )));
+
+    // Half-above vertically
+    otherWindow->setCoordinates( QRectF( QPointF( 0, 100 ), size ));
+    BOOST_CHECK_EQUAL( helper.getVisibleArea( *window ),
+                       QRectF( QPointF( 0, 0 ), QSize( 200, 100 )));
+
+    // Corner overlap (no cut)
+    otherWindow->setCoordinates( QRectF( QPointF( 100, 100 ), size ));
+    BOOST_CHECK_EQUAL( helper.getVisibleArea( *window ),
+                       QRectF( QPointF( 0, 0 ), QSize( 200, 200 )));
+}
+
+BOOST_FIXTURE_TEST_CASE( testUnderlyingWindow, Fixture )
+{
+    const QRectF& coord = window->getCoordinates();
+
+    ContentWindowPtr otherWindow = boost::make_shared<ContentWindow>( content );
+    group->addContentWindow( otherWindow );
+    BOOST_CHECK_EQUAL( helper.getVisibleArea( *window ), QRectF( ));
+    BOOST_CHECK_EQUAL( helper.getVisibleArea( *otherWindow ), coord );
+
+    group->moveContentWindowToFront( window );
+    BOOST_CHECK_EQUAL( helper.getVisibleArea( *otherWindow ), QRectF( ));
+    BOOST_CHECK_EQUAL( helper.getVisibleArea( *window ), coord );
+}
+
+BOOST_FIXTURE_TEST_CASE( testViewCutCombinedWithOverlappingWindow, Fixture )
+{
+    ContentWindowPtr otherWindow = boost::make_shared<ContentWindow>( content );
+    group->addContentWindow( otherWindow );
+
+    // Corner view cut
+    window->setCoordinates( QRectF( QPointF( 300, 500 ), size ));
+    BOOST_CHECK_EQUAL( helper.getVisibleArea( *window ),
+                       QRectF( QPointF( 0, 0 ), QSize( 100, 100 )));
+
+    // Partial corner overlap (no cut)
+    otherWindow->setCoordinates( QRectF( QPointF( 150, 350 ), size ));
+    BOOST_CHECK_EQUAL( helper.getVisibleArea( *window ),
+                       QRectF( QPointF( 0, 0 ), QSize( 100, 100 )));
+
+    // Full corner overlap
+    otherWindow->setCoordinates( QRectF( QPointF( 200, 400 ), size ));
+    BOOST_CHECK_EQUAL( helper.getVisibleArea( *window ), QRectF( ));
+}


### PR DESCRIPTION
* Currently used by DynamicTexture, TODO other content types
* ContentWindow decorations (titles, border) are added outside the windows
  and no longer alter their positions