### PR TITLE
Improved PixelStream update step, fix visiblity check for focused windows

### DIFF
--- a/dc/core/MovieProvider.cpp
+++ b/dc/core/MovieProvider.cpp
@@ -68,16 +68,10 @@ QImage MovieProvider::requestImage( const QString& id, QSize* size,
     if( !_movies.count( movieFile ))
         return QImage();
 
-    PicturePtr picture = _movies[ movieFile ]->getPicture();
-    if( !picture )
-        return QImage();
-
-    QImage image = picture->toQImage();
+    QImage image = _movies[ movieFile ]->getImage();
 
     if( !requestedSize.isEmpty( ))
         image = image.scaled( requestedSize );
-    else
-        image = image.copy();
 
     *size = image.size();
     return image;

--- a/dc/core/MovieSynchronizer.cpp
+++ b/dc/core/MovieSynchronizer.cpp
@@ -43,12 +43,13 @@
 #include "MovieContent.h"
 #include "MovieProvider.h"
 #include "MovieUpdater.h"
+#include "Tile.h"
 
 MovieSynchronizer::MovieSynchronizer( const QString& uri,
                                       MovieProvider& provider )
     : _provider( provider )
     , _uri( uri )
-    , _timestamp( 0.0 )
+    , _timestamp( -1.0 )
 {
     _updater = _provider.open( uri );
     connect( _updater.get(), SIGNAL( pictureUpdated( double )),
@@ -65,8 +66,6 @@ void MovieSynchronizer::update( const ContentWindow& window,
 {
     _updater->update( static_cast<const MovieContent&>( *window.getContent( )));
     _updater->setVisible( !visibleArea.isEmpty( ));
-
-    BasicSynchronizer::update( window, visibleArea );
 }
 
 QString MovieSynchronizer::getSourceParams() const
@@ -86,6 +85,10 @@ QString MovieSynchronizer::getStatistics() const
 
 void MovieSynchronizer::onPictureUpdated( const double timestamp )
 {
+    // Delay making the Tile visible until first picture is ready
+    if( _timestamp < 0.0 && _updater->isVisible( ))
+        qobject_cast<Tile*>( getTiles().front( ))->setVisible( true );
+
     _timestamp = timestamp;
     emit sourceParamsChanged();
 

--- a/dc/core/MovieUpdater.cpp
+++ b/dc/core/MovieUpdater.cpp
@@ -66,6 +66,11 @@ MovieUpdater::MovieUpdater( const QString& uri )
 
 MovieUpdater::~MovieUpdater() {}
 
+bool MovieUpdater::isVisible() const
+{
+    return _visible;
+}
+
 void MovieUpdater::setVisible( const bool visible )
 {
     _visible = visible;
@@ -114,9 +119,12 @@ void MovieUpdater::sync( WallToWallChannel& channel )
         _futurePicture = _ffmpegMovie->getFrame( _sharedTimestamp );
 }
 
-PicturePtr MovieUpdater::getPicture()
+QImage MovieUpdater::getImage() const
 {
-    return _currentPicture;
+    if( !_currentPicture )
+        return QImage();
+
+    return _currentPicture->toQImage();
 }
 
 double MovieUpdater::_getDelay() const

--- a/dc/core/MovieUpdater.h
+++ b/dc/core/MovieUpdater.h
@@ -59,11 +59,13 @@ public:
     explicit MovieUpdater( const QString& uri );
     ~MovieUpdater();
 
+    bool isVisible() const;
     void setVisible( bool visible );
+
     void update( const MovieContent& movie );
     void sync( WallToWallChannel& channel );
 
-    PicturePtr getPicture();
+    QImage getImage() const;
 
 signals:
     void pictureUpdated( double timestamp );

--- a/dc/core/PixelStreamProvider.cpp
+++ b/dc/core/PixelStreamProvider.cpp
@@ -61,11 +61,6 @@ QImage PixelStreamProvider::requestImage( const QString& id, QSize* size,
     const QString& streamUri = params[0];
 
     bool ok = false;
-    const uint frameIndex = params[1].toUInt( &ok );
-    if( !ok )
-        return QImage();
-
-    ok = false;
     const uint tileIndex = params[2].toUInt( &ok );
     if( !ok )
         return QImage();
@@ -75,7 +70,7 @@ QImage PixelStreamProvider::requestImage( const QString& id, QSize* size,
 
     QImage image;
     try {
-        image = _streams[streamUri]->getTileImage( frameIndex, tileIndex );
+        image = _streams[streamUri]->getTileImage( tileIndex );
     }
     catch ( const std::out_of_range& ) {
         put_flog( LOG_DEBUG, "Invalid tile requested: %d", tileIndex );

--- a/dc/core/PixelStreamSynchronizer.cpp
+++ b/dc/core/PixelStreamSynchronizer.cpp
@@ -54,7 +54,7 @@ PixelStreamSynchronizer::PixelStreamSynchronizer( const QString& uri,
     _updater = _provider.open( uri );
 
     connect( _updater.get(), &PixelStreamUpdater::pictureUpdated,
-             this, &PixelStreamSynchronizer::onPictureUpdated );
+             this, &PixelStreamSynchronizer::_onPictureUpdated );
     connect( _updater.get(), &PixelStreamUpdater::tilesChanged,
              this, &ContentSynchronizer::tilesChanged );
 }
@@ -99,10 +99,13 @@ QString PixelStreamSynchronizer::getStatistics() const
     return _fpsCounter.toString();
 }
 
-void PixelStreamSynchronizer::onPictureUpdated( const uint frameIndex )
+void PixelStreamSynchronizer::_onPictureUpdated( const bool requestImageUpdate )
 {
-    _frameIndex = frameIndex;
-    emit sourceParamsChanged();
+    if( requestImageUpdate )
+    {
+        ++_frameIndex;
+        emit sourceParamsChanged();
+    }
 
     _fpsCounter.tick();
     emit statisticsChanged();

--- a/dc/core/PixelStreamSynchronizer.h
+++ b/dc/core/PixelStreamSynchronizer.h
@@ -95,7 +95,7 @@ private:
     uint _frameIndex;
     FpsCounter _fpsCounter;
 
-    void onPictureUpdated( uint frameIndex );
+    void _onPictureUpdated( bool requestImageUpdate );
 };
 
 #endif

--- a/dc/core/PixelStreamUpdater.h
+++ b/dc/core/PixelStreamUpdater.h
@@ -67,7 +67,7 @@ public:
     /**
      * Get a segment by its frame- and tile-index.
      */
-    QImage getTileImage( uint frameIndex, uint tileIndex );
+    QImage getTileImage( uint tileIndex );
 
     /** Get the list of tiles for use by QML repeater. */
     const Tiles& getTiles() const;
@@ -81,33 +81,31 @@ public slots:
 
 signals:
     /** Emitted when a new picture has become available. */
-    void pictureUpdated( uint frameIndex );
+    void pictureUpdated( bool requestImageUpdate );
 
     /** Emitted to request a new frame after a successful swap. */
     void requestFrame( QString uri );
 
-    /** Emitted when the number of tiles has changed after a successful swap. */
+    /** Emitted when the number of tiles has changed. */
     void tilesChanged();
 
 private:
     typedef SwapSyncObject<deflect::FramePtr> SwapSyncFrame;
     SwapSyncFrame _swapSyncFrame;
 
-    std::deque< std::pair< size_t, deflect::FramePtr > > _frames;
-
-    uint _frameIndex;
-    uint _requestedFrameIndex;
+    deflect::FramePtr _currentFrame;
 
     Tiles _tiles;
     QRectF _visibleArea;
+    bool _tilesDirty;
 
     typedef std::vector<size_t> SegmentIndices;
     SegmentIndices _visibleSet;
 
     void _onFrameSwapped( deflect::FramePtr frame );
     void _decodeSegments( deflect::Segments& segments );
-    void _computeVisibleSet( const deflect::Segments& segments );
-    void _refreshTiles( const deflect::Segments& segments );
+    SegmentIndices _computeVisibleSet( const deflect::Segments& segments) const;
+    bool _refreshTiles( const deflect::Segments& segments );
 };
 
 #endif

--- a/dc/core/QmlWindowRenderer.cpp
+++ b/dc/core/QmlWindowRenderer.cpp
@@ -84,9 +84,9 @@ void QmlWindowRenderer::update( ContentWindowPtr contentWindow,
     _contentSynchronizer->update( *_contentWindow, visibleArea );
 }
 
-void QmlWindowRenderer::setStackingOrder( const int value )
+QQuickItem* QmlWindowRenderer::getQuickItem()
 {
-    _windowItem->setProperty( "stackingOrder", value );
+    return _windowItem;
 }
 
 ContentWindowPtr QmlWindowRenderer::getContentWindow()

--- a/dc/core/QmlWindowRenderer.h
+++ b/dc/core/QmlWindowRenderer.h
@@ -63,8 +63,8 @@ public:
     /** Update the qml object with a new data model. */
     void update( ContentWindowPtr contentWindow, const QRectF& visibleArea );
 
-    /** Set the z value of the window. */
-    void setStackingOrder( int value );
+    /** Get the QML item. */
+    QQuickItem* getQuickItem();
 
     /** Get the ContentWindow. */
     ContentWindowPtr getContentWindow();

--- a/dc/core/VisibilityHelper.cpp
+++ b/dc/core/VisibilityHelper.cpp
@@ -48,7 +48,7 @@ VisibilityHelper::VisibilityHelper( const DisplayGroup& displayGroup,
     , _visibleArea( visibleArea )
 {}
 
-QRectF cutOverlap( const QRectF& window, const QRectF& other )
+QRectF _cutOverlap( const QRectF& window, const QRectF& other )
 {
     if( other.contains( window ))
         return QRectF();
@@ -90,6 +90,9 @@ QRectF VisibilityHelper::getVisibleArea( const ContentWindow& window ) const
     if( area.isEmpty( ))
         return area;
 
+    if( window.isFocused( ))
+        return area.translated( -windowCoords.x(), -windowCoords.y( ));
+
     bool isAbove = false;
     for( auto win : _displayGroup.getContentWindows( ))
     {
@@ -99,7 +102,7 @@ QRectF VisibilityHelper::getVisibleArea( const ContentWindow& window ) const
             continue;
         }
         if( isAbove || win->isFocused( ))
-            area = cutOverlap( area, win->getDisplayCoordinates( ));
+            area = _cutOverlap( area, win->getDisplayCoordinates( ));
 
         if( area.isEmpty( ))
             return area;

--- a/dc/core/resources/BaseContentWindow.qml
+++ b/dc/core/resources/BaseContentWindow.qml
@@ -6,7 +6,6 @@ Rectangle {
     id: windowRect
 
     property alias titleBar: titleBar
-    property int stackingOrder: 0
     property bool isBackground: false
     property bool animating: widthAnimation.running || heightAnimation.running
                              || unfocusTransition.running
@@ -21,7 +20,7 @@ Rectangle {
 
     x: contentwindow.x - xOffset
     y: contentwindow.y - yOffset
-    z: stackingOrder
+    z: isBackground ? Style.backgroundZOrder : 0
     width: contentwindow.width + widthOffset
     height: contentwindow.height + heightOffset
 
@@ -58,7 +57,7 @@ Rectangle {
                 width: contentwindow.focusedCoordinates.width + widthOffset
                 height: contentwindow.focusedCoordinates.height + heightOffset
                 border.color: Style.windowBorderSelectedColor
-                z: stackingOrder + Style.focusZorder
+                z: Style.focusZorder
             }
         },
         State {

--- a/dc/core/resources/style.js
+++ b/dc/core/resources/style.js
@@ -1,5 +1,6 @@
 .pragma library
 
+var backgroundZOrder = -1;
 var focusTransitionTime = 500;
 var focusContextColor = "black"
 var focusContextOpacity = 0.7;

--- a/tests/cpp/core/VisibilityHelperTests.cpp
+++ b/tests/cpp/core/VisibilityHelperTests.cpp
@@ -136,6 +136,12 @@ BOOST_FIXTURE_TEST_CASE( testOverlappingWindow, Fixture )
     // Full overlap
     BOOST_CHECK_EQUAL( helper.getVisibleArea( *window ), QRectF( ));
 
+    // Focused
+    window->setFocusedCoordinates( coord );
+    window->setFocused( true );
+    BOOST_CHECK_EQUAL( helper.getVisibleArea( *window ), coord );
+    window->setFocused( false );
+
     // Half-above horizonally
     otherWindow->setCoordinates( QRectF( QPointF( 100, 0 ), size ));
     BOOST_CHECK_EQUAL( helper.getVisibleArea( *window ),


### PR DESCRIPTION
* fixes warnings due to incorrect frame index in getTileImage() when the
  tilesChanged() signal is emitted before pictureUpdated( _frameIndex++ )
* also decode segments to adjust to view changes when no frame is swapped
